### PR TITLE
feat: add per-parameter encoding toggle for path queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -547,6 +547,32 @@ In this example:
 
 These parameters are then used to construct the URL for the API call, with path parameters replacing placeholders in the endpoint's path, and query parameters appended to the URL.
 
+### Per-param encoding control
+
+Each element of `pathQueryParameters` can specify an optional `encode` flag to control URL encoding. The flag defaults to `true` for backward compatibility. When `encode` is set to `false`, the value is injected into the path without applying `encodeURIComponent`.
+
+#### Example
+
+```typescript
+// Previous behaviour (default encoding)
+path: '/api/search/products{queryParams}'
+serviceParams: {
+  pathQueryParameters: [
+    { name: 'queryParams', value: '?a=1&b=2' } // will be URL-encoded
+  ]
+}
+
+// With encode set to false
+path: '/api/search/products{queryParams}'
+serviceParams: {
+  pathQueryParameters: [
+    { name: 'queryParams', value: '?a=1&b=2', encode: false } // raw injection
+  ]
+}
+```
+
+Empty, undefined or null values remove the related placeholder and the library normalizes the resulting URL to avoid leftover separators. When `encode` is `false` and the value is an array, it will be serialized using `Array.prototype.join(',')` before being injected.
+
 ## Stack Trace Functionality
 
 The stack trace functionality offers a comprehensive logging mechanism for API calls, capturing essential details throughout the request-response lifecycle. This functionality creates a detailed log entry for each API interaction.

--- a/lib/API.js
+++ b/lib/API.js
@@ -303,8 +303,36 @@ var API = /** @class */ (function () {
             var newUrl = url;
             for (var _i = 0, queryParameters_1 = queryParameters; _i < queryParameters_1.length; _i++) {
                 var parameter = queryParameters_1[_i];
-                newUrl = newUrl.replace("{".concat(parameter.name, "}"), encodeURIComponent(parameter.value));
+                var placeholder = "{".concat(parameter.name, "}");
+                if (!newUrl.includes(placeholder))
+                    continue;
+                var rawValue = Array.isArray(parameter.value)
+                    ? parameter.value.join(',')
+                    : parameter.value == null
+                        ? ''
+                        : String(parameter.value);
+                if (rawValue.trim() === '') {
+                    var regex = new RegExp("([?&])[^?&=]*=".concat(placeholder, "(&?)"));
+                    if (regex.test(newUrl)) {
+                        newUrl = newUrl.replace(regex, function (match, sep, trailingAmp) {
+                            if (sep === '?' && trailingAmp)
+                                return '?';
+                            if (sep === '&' && trailingAmp)
+                                return '&';
+                            return '';
+                        });
+                    }
+                    else {
+                        newUrl = newUrl.replace(placeholder, '');
+                    }
+                    continue;
+                }
+                var shouldEncode = parameter.encode !== false;
+                var valueToInsert = shouldEncode ? encodeURIComponent(rawValue) : rawValue;
+                newUrl = newUrl.replace(placeholder, valueToInsert);
             }
+            newUrl = newUrl.replace(/([?&])([?&])/g, '$1');
+            newUrl = newUrl.replace(/[?&]$/g, '');
             return newUrl;
         };
         //generate url with path and query parameters

--- a/lib/types.d.ts
+++ b/lib/types.d.ts
@@ -62,7 +62,9 @@ export type ApiConstantsInternal = {
 };
 type Parameter = {
     name: string;
-    value: string;
+    value: any;
+    /** Default true. When false, the value is injected raw without URL-encoding. */
+    encode?: boolean;
 };
 export type PathQueryParameters = Parameter[];
 export type ApiParameters = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -73,7 +73,9 @@ export type ApiConstantsInternal = {
 
 type Parameter = {
     name: string;
-    value: string;
+    value: any;
+    /** Default true. When false, the value is injected raw without URL-encoding. */
+    encode?: boolean;
 };
 
 export type PathQueryParameters = Parameter[];

--- a/tests/JS.test.js
+++ b/tests/JS.test.js
@@ -758,4 +758,92 @@ describe('JavaScript tests', () => {
             expect(res.requestApi.extraParams).toEqual({ firstParam: 'firstParam', secondParam: 2 });
         });
     });
+
+    describe('Path query parameters encode option', () => {
+        const createApi = (path) =>
+            new APIEngine({
+                baseUrl: 'https://jsonplaceholder.typicode.com',
+                endpoints: { test: { path, request: { method: 'GET' }, retry: 0, retryCondition: [] } },
+            });
+
+        test('Default encoding when encode omitted', async () => {
+            const api = createApi('/posts{query}');
+            const res = await api.call('test', {
+                pathQueryParameters: [{ name: 'query', value: '?a=1&b=2' }],
+            });
+            expect(res.response.url).toBe('https://jsonplaceholder.typicode.com/posts%3Fa%3D1%26b%3D2');
+        });
+
+        test('Explicit encode true encodes value', async () => {
+            const api = createApi('/posts{query}');
+            const res = await api.call('test', {
+                pathQueryParameters: [{ name: 'query', value: '?a=1&b=2', encode: true }],
+            });
+            expect(res.response.url).toBe('https://jsonplaceholder.typicode.com/posts%3Fa%3D1%26b%3D2');
+        });
+
+        test('encode:false injects raw value', async () => {
+            const api = createApi('/posts{query}');
+            const res = await api.call('test', {
+                pathQueryParameters: [
+                    {
+                        name: 'query',
+                        value: '?errors=SENT&page=1&products_per_page=20',
+                        encode: false,
+                    },
+                ],
+            });
+            expect(res.response.url).toBe(
+                'https://jsonplaceholder.typicode.com/posts?errors=SENT&page=1&products_per_page=20'
+            );
+        });
+
+        test('Placeholder with empty value removed and URL clean', async () => {
+            const api = createApi('/posts?keyword={keyword}&page={page}');
+            const res = await api.call('test', {
+                pathQueryParameters: [
+                    { name: 'keyword', value: '' },
+                    { name: 'page', value: '1' },
+                ],
+            });
+            expect(res.response.url).toBe('https://jsonplaceholder.typicode.com/posts?page=1');
+        });
+
+        test('Mixed encode true and false', async () => {
+            const api = createApi('/posts?keyword={keyword}{query}');
+            const res = await api.call('test', {
+                pathQueryParameters: [
+                    { name: 'keyword', value: 'hello world' },
+                    { name: 'query', value: '&errors=SENT&page=1', encode: false },
+                ],
+            });
+            expect(res.response.url).toBe(
+                'https://jsonplaceholder.typicode.com/posts?keyword=hello%20world&errors=SENT&page=1'
+            );
+        });
+
+        test('Path already ends with ? and raw starts with ?', async () => {
+            const api = createApi('/posts?{query}');
+            const res = await api.call('test', {
+                pathQueryParameters: [{ name: 'query', value: '?a=1&b=2', encode: false }],
+            });
+            expect(res.response.url).toBe('https://jsonplaceholder.typicode.com/posts?a=1&b=2');
+        });
+
+        test('Array value with encode false', async () => {
+            const api = createApi('/posts?tags={tags}');
+            const res = await api.call('test', {
+                pathQueryParameters: [{ name: 'tags', value: ['a', 'b', 'c'], encode: false }],
+            });
+            expect(res.response.url).toBe('https://jsonplaceholder.typicode.com/posts?tags=a,b,c');
+        });
+
+        test('Parameter without placeholder is ignored', async () => {
+            const api = createApi('/posts');
+            const res = await api.call('test', {
+                pathQueryParameters: [{ name: 'missing', value: '1' }],
+            });
+            expect(res.response.url).toBe('https://jsonplaceholder.typicode.com/posts');
+        });
+    });
 });

--- a/tests/JS.test.js
+++ b/tests/JS.test.js
@@ -107,6 +107,26 @@ describe('JavaScript tests', () => {
             const res = await api.call(apiTypes.getUserResourcesWithCustomRoute, parameters);
             expect(res.response.status).toEqual(404);
         });
+
+        test('Empty query parameter removed from URL', async () => {
+            expect.assertions(2);
+            const parameters = {
+                pathQueryParameters: [{ name: 'id', value: '' }],
+            };
+            const res = await api.call(apiTypes.getUserResources, parameters);
+            expect(res.response.status).toEqual(200);
+            expect(res.response.url).toEqual(apiConstantsJs.baseUrl + '/posts');
+        });
+
+        test('Empty path parameter removed from URL', async () => {
+            expect.assertions(2);
+            const parameters = {
+                pathQueryParameters: [{ name: 'id', value: '' }],
+            };
+            const res = await api.call(apiTypes.getResource, parameters);
+            expect(res.response.status).toEqual(200);
+            expect(res.response.url).toMatch(new RegExp(`${apiConstantsJs.baseUrl}/posts/?$`));
+        });
     });
 
     describe('With headers and body REST API calls', () => {

--- a/tests/JS.test.js
+++ b/tests/JS.test.js
@@ -829,6 +829,18 @@ describe('JavaScript tests', () => {
             expect(res.response.url).toBe('https://jsonplaceholder.typicode.com/posts?page=1');
         });
 
+        test('Null parameter in middle removed and URL clean', async () => {
+            const api = createApi('/posts?category={category}&keyword={keyword}&page={page}');
+            const res = await api.call('test', {
+                pathQueryParameters: [
+                    { name: 'category', value: 'news' },
+                    { name: 'keyword', value: null },
+                    { name: 'page', value: '1' },
+                ],
+            });
+            expect(res.response.url).toBe('https://jsonplaceholder.typicode.com/posts?category=news&page=1');
+        });
+
         test('Mixed encode true and false', async () => {
             const api = createApi('/posts?keyword={keyword}{query}');
             const res = await api.call('test', {

--- a/tests/TS.test.ts
+++ b/tests/TS.test.ts
@@ -755,4 +755,92 @@ describe('TypeScript tests', () => {
             expect(res.requestApi.extraParams).toEqual({ firstParam: 'firstParam', secondParam: 2 });
         });
     });
+
+    describe('Path query parameters encode option', () => {
+        const createApi = (path: string) =>
+            new APIEngine({
+                baseUrl: 'https://jsonplaceholder.typicode.com',
+                endpoints: { test: { path, request: { method: 'GET' }, retry: 0, retryCondition: [] } },
+            });
+
+        test('Default encoding when encode omitted', async () => {
+            const api = createApi('/posts{query}');
+            const res = await api.call('test', {
+                pathQueryParameters: [{ name: 'query', value: '?a=1&b=2' }],
+            });
+            expect(res.response.url).toBe('https://jsonplaceholder.typicode.com/posts%3Fa%3D1%26b%3D2');
+        });
+
+        test('Explicit encode true encodes value', async () => {
+            const api = createApi('/posts{query}');
+            const res = await api.call('test', {
+                pathQueryParameters: [{ name: 'query', value: '?a=1&b=2', encode: true }],
+            });
+            expect(res.response.url).toBe('https://jsonplaceholder.typicode.com/posts%3Fa%3D1%26b%3D2');
+        });
+
+        test('encode:false injects raw value', async () => {
+            const api = createApi('/posts{query}');
+            const res = await api.call('test', {
+                pathQueryParameters: [
+                    {
+                        name: 'query',
+                        value: '?errors=SENT&page=1&products_per_page=20',
+                        encode: false,
+                    },
+                ],
+            });
+            expect(res.response.url).toBe(
+                'https://jsonplaceholder.typicode.com/posts?errors=SENT&page=1&products_per_page=20'
+            );
+        });
+
+        test('Placeholder with empty value removed and URL clean', async () => {
+            const api = createApi('/posts?keyword={keyword}&page={page}');
+            const res = await api.call('test', {
+                pathQueryParameters: [
+                    { name: 'keyword', value: '' },
+                    { name: 'page', value: '1' },
+                ],
+            });
+            expect(res.response.url).toBe('https://jsonplaceholder.typicode.com/posts?page=1');
+        });
+
+        test('Mixed encode true and false', async () => {
+            const api = createApi('/posts?keyword={keyword}{query}');
+            const res = await api.call('test', {
+                pathQueryParameters: [
+                    { name: 'keyword', value: 'hello world' },
+                    { name: 'query', value: '&errors=SENT&page=1', encode: false },
+                ],
+            });
+            expect(res.response.url).toBe(
+                'https://jsonplaceholder.typicode.com/posts?keyword=hello%20world&errors=SENT&page=1'
+            );
+        });
+
+        test('Path already ends with ? and raw starts with ?', async () => {
+            const api = createApi('/posts?{query}');
+            const res = await api.call('test', {
+                pathQueryParameters: [{ name: 'query', value: '?a=1&b=2', encode: false }],
+            });
+            expect(res.response.url).toBe('https://jsonplaceholder.typicode.com/posts?a=1&b=2');
+        });
+
+        test('Array value with encode false', async () => {
+            const api = createApi('/posts?tags={tags}');
+            const res = await api.call('test', {
+                pathQueryParameters: [{ name: 'tags', value: ['a', 'b', 'c'], encode: false }],
+            });
+            expect(res.response.url).toBe('https://jsonplaceholder.typicode.com/posts?tags=a,b,c');
+        });
+
+        test('Parameter without placeholder is ignored', async () => {
+            const api = createApi('/posts');
+            const res = await api.call('test', {
+                pathQueryParameters: [{ name: 'missing', value: '1' }],
+            });
+            expect(res.response.url).toBe('https://jsonplaceholder.typicode.com/posts');
+        });
+    });
 });

--- a/tests/TS.test.ts
+++ b/tests/TS.test.ts
@@ -826,6 +826,18 @@ describe('TypeScript tests', () => {
             expect(res.response.url).toBe('https://jsonplaceholder.typicode.com/posts?page=1');
         });
 
+        test('Null parameter in middle removed and URL clean', async () => {
+            const api = createApi('/posts?category={category}&keyword={keyword}&page={page}');
+            const res = await api.call('test', {
+                pathQueryParameters: [
+                    { name: 'category', value: 'news' },
+                    { name: 'keyword', value: null },
+                    { name: 'page', value: '1' },
+                ],
+            });
+            expect(res.response.url).toBe('https://jsonplaceholder.typicode.com/posts?category=news&page=1');
+        });
+
         test('Mixed encode true and false', async () => {
             const api = createApi('/posts?keyword={keyword}{query}');
             const res = await api.call('test', {

--- a/tests/TS.test.ts
+++ b/tests/TS.test.ts
@@ -104,6 +104,26 @@ describe('TypeScript tests', () => {
             const res = await api.call(apiTypes.getUserResourcesWithCustomRoute, parameters);
             expect(res.response.status).toEqual<number>(404);
         });
+
+        test('Empty query parameter removed from URL', async () => {
+            expect.assertions(2);
+            const parameters: ApiParameters = {
+                pathQueryParameters: [{ name: 'id', value: '' }],
+            };
+            const res = await api.call(apiTypes.getUserResources, parameters);
+            expect(res.response.status).toEqual<number>(200);
+            expect(res.response.url).toEqual<string>(apiConstantsTs.baseUrl + '/posts');
+        });
+
+        test('Empty path parameter removed from URL', async () => {
+            expect.assertions(2);
+            const parameters: ApiParameters = {
+                pathQueryParameters: [{ name: 'id', value: '' }],
+            };
+            const res = await api.call(apiTypes.getResource, parameters);
+            expect(res.response.status).toEqual<number>(200);
+            expect(res.response.url).toMatch(new RegExp(`${apiConstantsTs.baseUrl}/posts/?$`));
+        });
     });
 
     describe('With headers and body REST API calls', () => {


### PR DESCRIPTION
## Summary
- allow PathQueryParameters to opt-out of URL encoding via `encode` flag
- document and test per-parameter encoding control

## Testing
- `npm test` *(fails: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_689c9b0dbd54832c9fce9c8fecd793f9