### PR TITLE
test: cover empty parameter removal

### DIFF
--- a/tests/JS.test.js
+++ b/tests/JS.test.js
@@ -107,6 +107,26 @@ describe('JavaScript tests', () => {
             const res = await api.call(apiTypes.getUserResourcesWithCustomRoute, parameters);
             expect(res.response.status).toEqual(404);
         });
+
+        test('Empty query parameter removed from URL', async () => {
+            expect.assertions(2);
+            const parameters = {
+                pathQueryParameters: [{ name: 'id', value: '' }],
+            };
+            const res = await api.call(apiTypes.getUserResources, parameters);
+            expect(res.response.status).toEqual(200);
+            expect(res.response.url).toEqual(apiConstantsJs.baseUrl + '/posts');
+        });
+
+        test('Empty path parameter removed from URL', async () => {
+            expect.assertions(2);
+            const parameters = {
+                pathQueryParameters: [{ name: 'id', value: '' }],
+            };
+            const res = await api.call(apiTypes.getResource, parameters);
+            expect(res.response.status).toEqual(200);
+            expect(res.response.url).toMatch(new RegExp(`${apiConstantsJs.baseUrl}/posts/?$`));
+        });
     });
 
     describe('With headers and body REST API calls', () => {

--- a/tests/TS.test.ts
+++ b/tests/TS.test.ts
@@ -104,6 +104,26 @@ describe('TypeScript tests', () => {
             const res = await api.call(apiTypes.getUserResourcesWithCustomRoute, parameters);
             expect(res.response.status).toEqual<number>(404);
         });
+
+        test('Empty query parameter removed from URL', async () => {
+            expect.assertions(2);
+            const parameters: ApiParameters = {
+                pathQueryParameters: [{ name: 'id', value: '' }],
+            };
+            const res = await api.call(apiTypes.getUserResources, parameters);
+            expect(res.response.status).toEqual<number>(200);
+            expect(res.response.url).toEqual<string>(apiConstantsTs.baseUrl + '/posts');
+        });
+
+        test('Empty path parameter removed from URL', async () => {
+            expect.assertions(2);
+            const parameters: ApiParameters = {
+                pathQueryParameters: [{ name: 'id', value: '' }],
+            };
+            const res = await api.call(apiTypes.getResource, parameters);
+            expect(res.response.status).toEqual<number>(200);
+            expect(res.response.url).toMatch(new RegExp(`${apiConstantsTs.baseUrl}/posts/?$`));
+        });
     });
 
     describe('With headers and body REST API calls', () => {


### PR DESCRIPTION
## Summary
- test removal of empty query parameters
- test removal of empty path parameters

## Testing
- `npm test` *(fails: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_689ca1082d00832caa437bc5fb45e2f1